### PR TITLE
config: integrate REPO_MAP generator with build system

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,14 @@ repos:
         files: ""  # run always
         stages: [pre-commit]
         args: ["scripts/validate_schemas.py", "--check-source-files"]
+      - id: python-syntax-check
+        name: Python syntax compatibility check
+        entry: python3
+        language: system
+        pass_filenames: true
+        files: \.py$
+        stages: [pre-commit]
+        args: ["-m", "py_compile"]
 
 # Global excludes to speed up hooks that still look at repo root
 exclude: |

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 # LLM-First Makefile for Zelox
 # Provides consistent targets for LLM-friendly development workflow
 
-.PHONY: help pr.loc llm.check test.fast clean confusion.report cost.report pr.check validate.schemas llm.index.validate
+.PHONY: help pr.loc llm.check test.fast clean confusion.report cost.report pr.check validate.schemas llm.index.validate llm.map llm.map.check
 
 # Default target
 help:
 	@echo "LLM-First Development Targets:"
 	@echo "  pr.loc          - Check PR size limits (excludes Markdown)"
 	@echo "  llm.check       - Run LLM readiness checks"
+	@echo "  llm.map         - Auto-generate REPO_MAP.md from codebase"
+	@echo "  llm.map.check   - Validate REPO_MAP.md is up-to-date"
 	@echo "  test.fast       - Run fast test suite"
 	@echo "  clean           - Clean temporary files"
 
@@ -53,6 +55,16 @@ validate.schemas:
 llm.index.validate:
 	@echo "Validating INDEX.yaml with cross-validation..."
 	@python3 scripts/validate_schemas.py
+
+# Auto-generate REPO_MAP.md from codebase
+llm.map:
+	@echo "Auto-generating REPO_MAP.md..."
+	@python3 scripts/gen_repo_map.py
+
+# Validate REPO_MAP.md is up-to-date
+llm.map.check:
+	@echo "Validating REPO_MAP.md is up-to-date..."
+	@python3 scripts/gen_repo_map.py --dry-run
 
 # Clean temporary files
 clean:


### PR DESCRIPTION
## Summary
Complete REPO_MAP generator integration by adding Makefile targets and enhanced pre-commit hooks.

## Makefile Integration
### New Targets
- **`make llm.map`**: Auto-generate REPO_MAP.md from current codebase
- **`make llm.map.check`**: Validate REPO_MAP.md is up-to-date (dry-run mode)
- **Updated help**: New targets included in `make help` output
- **PHONY declaration**: Proper Make target declarations

### Usage Examples
```bash
# Generate REPO_MAP.md
make llm.map

# Validate without writing (useful in CI)
make llm.map.check

# See all targets
make help
```

## Pre-commit Enhancements
### Python Syntax Check
- **python-syntax-check**: New hook using `python3 -m py_compile`  
- **Purpose**: Catch Python version compatibility issues before commit
- **Prevents**: F-string escape sequence errors (Python 3.11 compatibility)
- **Scope**: All `.py` files

## Configuration Stats
- **22 LOC total** - well under config limits ✅
  - CONFIG: 14 LOC (14/250 limit)
  - APPLICATION: 8 LOC (8/500 limit) 
- **2 files modified**: Makefile, .pre-commit-config.yaml
- **No breaking changes** to existing workflows

## Dependencies
- **Base branch**: `feat/repo-map-core` (includes core functionality)
- **Requires**: PR #5 to be merged first
- **Part 3 of 3**: Completes the REPO_MAP implementation trilogy

## Integration Testing
- ✅ All pre-commit hooks pass
- ✅ New Makefile targets work correctly  
- ✅ Python syntax check prevents compatibility issues
- ✅ No conflicts with existing build system

This completes the full REPO_MAP auto-generation system integration into the development workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)